### PR TITLE
fix: Update Docs for custom Vencord location in Vesktop

### DIFF
--- a/src/content/docs/installing/index.mdx
+++ b/src/content/docs/installing/index.mdx
@@ -118,9 +118,9 @@ The installation process differs depending on the platform you want to install o
     <TabItem label="Vesktop">
         1. Open Vesktop
         2. Go to the Vesktop Settings category
-        3. Scroll down all the way to the `Vencord Location` section
-        4. Press `Change` and select the `dist` folder in your Vencord directory. For example, if you stuck to the example above, you would select `Documents/Vencord/dist`
-        5. Fully close and restart Vesktop and you're done!
+        3. Scroll down all the way to the `Open Developer Settings` button, and click it.
+        5. Under `Vencord Location`, Press `Change` and select the `dist` folder in your Vencord directory. For example, if you stuck to the example above, you would select `Documents/Vencord/dist`
+        6. Fully close and restart Vesktop and you're done!
 
         <Aside type="caution">
             If you are using the Vesktop flatpak on Linux, the path might turn into `/run/1000/...`.

--- a/src/content/docs/installing/index.mdx
+++ b/src/content/docs/installing/index.mdx
@@ -119,8 +119,8 @@ The installation process differs depending on the platform you want to install o
         1. Open Vesktop
         2. Go to the Vesktop Settings category
         3. Scroll down all the way to the `Open Developer Settings` button, and click it.
-        5. Under `Vencord Location`, Press `Change` and select the `dist` folder in your Vencord directory. For example, if you stuck to the example above, you would select `Documents/Vencord/dist`
-        6. Fully close and restart Vesktop and you're done!
+        4. Under `Vencord Location`, Press `Change` and select the `dist` folder in your Vencord directory. For example, if you stuck to the example above, you would select `Documents/Vencord/dist`
+        5. Fully close and restart Vesktop and you're done!
 
         <Aside type="caution">
             If you are using the Vesktop flatpak on Linux, the path might turn into `/run/1000/...`.


### PR DESCRIPTION
The "Change Vencord Location" option is now concealed inside of the "Vesktop Developer Options" menu, so this updates the docs to guide people to the  right location.
![image](https://github.com/user-attachments/assets/ff8dda3c-0bda-4000-8876-f6c0e763b397)
![image](https://github.com/user-attachments/assets/d5ae879c-abfd-4e44-935f-fafbe3ac61cb)
